### PR TITLE
In IE11 linked stylesheets were not being included

### DIFF
--- a/css-var-polyfill.js
+++ b/css-var-polyfill.js
@@ -32,7 +32,7 @@ let cssVarPoly = {
   
   // find all the css blocks, save off the content, and look for variables
   findCSS: function() {
-    let styleBlocks = document.querySelectorAll('style:not(.inserted),link[type="text/css"]');
+    let styleBlocks = document.querySelectorAll('style:not(.inserted),link[rel="stylesheet"]');
 
     // we need to track the order of the style/link elements when we save off the CSS, set a counter
     let counter = 1;


### PR DESCRIPTION
In IE11 the linked stylesheet in index.html was not being found because it doesn't list a type:
  <link rel="stylesheet" href="css/style.css">

So I changed css-var-polyfill.js to select linked styles based on the rel attribute instead of type.