### PR TITLE
IE11 fails on whitespace typo in responseText

### DIFF
--- a/css-var-polyfill.js
+++ b/css-var-polyfill.js
@@ -49,7 +49,7 @@ let cssVarPoly = {
         // console.log("link");
         cssVarPoly.getLink(block.getAttribute('href'), counter, function(counter, request) {
           cssVarPoly.findSetters(request.responseText, counter);
-          cssVarPoly.oldCSS[counter] = request.r esponseText;
+          cssVarPoly.oldCSS[counter] = request.responseText;
           cssVarPoly.updateCSS();
         });
         theCSS = '';


### PR DESCRIPTION
There was a typo in "request.responseText" that was causing an error in IE11. Seemed to work in chrome for me though. Got to love JS =)