### PR TITLE
Updated regex on findSetters

### DIFF
--- a/css-var-polyfill.js
+++ b/css-var-polyfill.js
@@ -63,7 +63,7 @@ let cssVarPoly = {
   // find all the "--variable: value" matches in a provided block of CSS and add them to the master list
   findSetters: function(theCSS, counter) {
     // console.log(theCSS);
-    cssVarPoly.varsByBlock[counter] = theCSS.match(/(--.+:.+;)/g) || [];
+    cssVarPoly.varsByBlock[counter] = theCSS.match(/(--[a-zA-z0-9]+[a-zA-Z0-9\-\_]+ *:.+;?\}?)/g) || [];
   },
 
   // run through all the CSS blocks to update the variables and then inject on the page


### PR DESCRIPTION
Updated the regex to work when the file is minified. The old regex only worked when there was a line break present. The new regex works when multiple references are on the same line.